### PR TITLE
Treat UAVS diffrently from manned aviation

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -945,6 +945,16 @@ void Navigator::check_traffic()
 
 	float horizontal_separation = 500;
 	float vertical_separation = 500;
+		
+
+
+	//TODO a better denomination if the other Vehicle is manned or an UAV
+	//Right now it decides on there being an ADSB emitter
+	if (NULL == transponder_report_s::emitter_type) {
+		float horizontal_separation = 10;
+		float vertical_separation = 10;
+	}
+
 
 	while (changed) {
 


### PR DESCRIPTION
Using ADSB transmitter data existing or not.

A seperation distance of 10 Meters should suffice for D2D Collision avoidance.

This is needed to test the collision avoidance of UAVs. 500 Meters is an unnecessary Distance for UAVs.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by the proposed pull request**
500 Meters is an unnecessary Distance for UAV to UAV Collision avoidance


**Describe your preferred solution**
A Flag that decides if the encountered entity is Manned or an UAV



**Additional context**
Collision avoidance uses UTM_Global_Position as per this [PR](https://github.com/PX4/Firmware/pull/12452)
Testing Collision avoidance would mean a seperation distance of 500 meters.
